### PR TITLE
Create action to get release notes from merged PRs with GitHub API

### DIFF
--- a/create-github-release/action.yml
+++ b/create-github-release/action.yml
@@ -1,0 +1,69 @@
+name: Create GitHub release
+description: Create GitHub release with release notes from merged PRs
+inputs:
+  token:
+    description: 'A Github PAT'
+    required: true
+  tag-name:
+    description: 'Name of the tag being released'
+    required: false
+    default: ${{ github.ref }}
+  release-name:
+    description: 'Name of the release being created'
+    required: false
+    default: ${{ github.ref }}
+runs:
+  using: "composite"
+  steps:
+    - name: Get base branch
+      id: get_base_branch
+      uses: "smartlyio/github-actions@get-base-branch-v1"
+      with:
+        token: "${{ inputs.token }}"
+    - name: Get merge window
+      id: merge-window
+      env:
+        TAG_NAME: ${{ inputs.tag-name }}
+      run: ${{ github.action_path }}/get-merge-window.sh
+      shell: bash
+    - name: Get merged PRs
+      uses: octokit/graphql-action@v2.x
+      id: get-release-prs
+      with:
+        query: |
+          query($filter: String!) {
+            search(query:$filter, type: ISSUE, last: 100) {
+              edges {
+                node {
+                  ... on PullRequest {
+                    number
+                    mergedAt
+                    title
+                    mergeCommit {
+                      author {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        filter: repo:${{ github.repository }} is:pr base:${{ steps.get_base_branch.outputs.git_base_branch }} merged:${{ steps.merge-window.outputs.start_date }}..${{ steps.merge-window.outputs.end_date }}
+    - name: Get release message
+      id: release-message
+      env:
+        PR_DATA: ${{ steps.get-release-prs.outputs.data }}
+      run: ${{ github.action_path }}/get-release-changes.sh
+      shell: bash
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      with:
+        tag_name: ${{ inputs.tag-name }}
+        release_name: ${{ inputs.release-name }}
+        body: |
+          ${{ steps.release-message.outputs.changes }}
+        draft: false
+        prerelease: false

--- a/create-github-release/action.yml
+++ b/create-github-release/action.yml
@@ -30,6 +30,7 @@ runs:
       uses: octokit/graphql-action@v2.x
       id: get-release-prs
       with:
+        token: ${{ inputs.token }}
         query: |
           query($filter: String!) {
             search(query:$filter, type: ISSUE, last: 100) {

--- a/create-github-release/get-merge-window.sh
+++ b/create-github-release/get-merge-window.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-this_tag="$TAG_NAME"
+this_tag="${TAG_NAME/#refs\/tags\//}"
 
 recent_tags="$(git tag --sort=creatordate --list 'v*' | grep -P 'v\d+\.\d+\.\d+' | grep --color=no -B1 "$this_tag")"
 previous_tag="$(echo "$recent_tags" | head -n1)"

--- a/create-github-release/get-merge-window.sh
+++ b/create-github-release/get-merge-window.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+this_tag="$TAG_NAME"
+
+recent_tags="$(git tag --sort=creatordate --list 'v*' | grep -P 'v\d+\.\d+\.\d+' | grep --color=no -B1 "$this_tag")"
+previous_tag="$(echo "$recent_tags" | head -n1)"
+
+previous_tag_date="$(git log -1 --tags --no-walk --pretty="format:%%cI" "$previous_tag")"
+this_tag_date="$(git log -1 --tags --no-walk --pretty="format:%%cI" "$this_tag")"
+
+start_date="$(date -Is -d "$previous_tag_date")"
+end_date="$(date -Is -d "$this_tag_date")"
+
+{
+  echo "start_date=$start_date"
+  echo "end_date=$end_date"
+} >> "$GITHUB_OUTPUT"

--- a/create-github-release/get-merge-window.sh
+++ b/create-github-release/get-merge-window.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 this_tag="${TAG_NAME/#refs\/tags\//}"
 
-recent_tags="$(git tag --sort=creatordate --list 'v*' | grep -P 'v\d+\.\d+\.\d+' | grep --color=no -B1 "$this_tag")"
+recent_tags="$(git tag --sort=creatordate --list 'v*' | grep -P 'v\d+\.\d+\.\d+' | grep --color=no -B1 "^$this_tag\$")"
 previous_tag="$(echo "$recent_tags" | head -n1)"
 
 previous_tag_date="$(git log -1 --tags --no-walk --pretty="format:%%cI" "$previous_tag")"

--- a/create-github-release/get-merge-window.sh
+++ b/create-github-release/get-merge-window.sh
@@ -7,8 +7,8 @@ this_tag="${TAG_NAME/#refs\/tags\//}"
 recent_tags="$(git tag --sort=creatordate --list 'v*' | grep -P 'v\d+\.\d+\.\d+' | grep --color=no -B1 "^$this_tag\$")"
 previous_tag="$(echo "$recent_tags" | head -n1)"
 
-previous_tag_date="$(git log -1 --tags --no-walk --pretty="format:%%cI" "$previous_tag")"
-this_tag_date="$(git log -1 --tags --no-walk --pretty="format:%%cI" "$this_tag")"
+previous_tag_date="$(git log -1 --tags --no-walk --pretty="format:%cI" "$previous_tag")"
+this_tag_date="$(git log -1 --tags --no-walk --pretty="format:%cI" "$this_tag")"
 
 start_date="$(date -Is -d "$previous_tag_date")"
 end_date="$(date -Is -d "$this_tag_date")"

--- a/create-github-release/get-merge-window.sh
+++ b/create-github-release/get-merge-window.sh
@@ -7,8 +7,8 @@ this_tag="${TAG_NAME/#refs\/tags\//}"
 recent_tags="$(git tag --sort=creatordate --list 'v*' | grep -P 'v\d+\.\d+\.\d+' | grep --color=no -B1 "^$this_tag\$")"
 previous_tag="$(echo "$recent_tags" | head -n1)"
 
-previous_tag_date="$(git log -1 --tags --no-walk --pretty="format:%cI" "$previous_tag")"
-this_tag_date="$(git log -1 --tags --no-walk --pretty="format:%cI" "$this_tag")"
+previous_tag_date="$(git log -1 --no-walk --pretty="format:%cI" "$previous_tag")"
+this_tag_date="$(git log -1 --no-walk --pretty="format:%cI" "$this_tag")"
 
 start_date="$(date -Is -d "$previous_tag_date")"
 end_date="$(date -Is -d "$this_tag_date")"

--- a/create-github-release/get-release-changes.sh
+++ b/create-github-release/get-release-changes.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 {
   echo 'changes<<EOF_RELEASE_CHANGES'
-  echo "$PR_DATA" | jq -r '.data.search.edges[] | .node | "- " + "#" + (.number | tostring) + " " + .title + " [" + .mergeCommit.author.name + "]"'
+  echo "$PR_DATA" | jq -r '.search.edges[] | .node | "- " + "#" + (.number | tostring) + " " + .title + " [" + .mergeCommit.author.name + "]"'
   echo 'EOF_RELEASE_CHANGES'
 } >> "$GITHUB_OUTPUT"

--- a/create-github-release/get-release-changes.sh
+++ b/create-github-release/get-release-changes.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+{
+  echo 'changes<<EOF_RELEASE_CHANGES'
+  echo "$PR_DATA" | jq -r '.data.search.edges[] | .node | "- " + "#" + (.number | tostring) + " " + .title + " [" + .mergeCommit.author.name + "]"'
+  echo 'EOF_RELEASE_CHANGES'
+} >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Instead of inspecting local commits for release notes, which is difficult when dealing with squash-merges (they have only one parent, and the text is formatted differently from regular merges), we build a graphql query to get PRs merged between two tags, and retrieve the PR titles, numbers and author information from there.