### PR TITLE
Support different tag filters for formats other than vN.N.N

### DIFF
--- a/create-github-release/action.yml
+++ b/create-github-release/action.yml
@@ -12,6 +12,14 @@ inputs:
     description: 'Name of the release being created'
     required: false
     default: ${{ github.ref }}
+  tag-search-prefix:
+    description: "Prefix for tags to search in git repository to find previous release"
+    required: false
+    default: "v"
+  tag-search-regex:
+    description: "grep -P regexp to further filter searched tags (e.g. exclude alphas)"
+    required: false
+    default: "v\\d+\\.\\d+\\.\\d+"
 runs:
   using: "composite"
   steps:
@@ -23,6 +31,8 @@ runs:
     - name: Get merge window
       id: merge-window
       env:
+        TAG_SEARCH_PREFIX: ${{ inputs.tag-search-prefix }}
+        TAG_SEARCH_REGEX: ${{ inputs.tag-search-regex }}
         TAG_NAME: ${{ inputs.tag-name }}
       run: ${{ github.action_path }}/get-merge-window.sh
       shell: bash

--- a/create-github-release/get-merge-window.sh
+++ b/create-github-release/get-merge-window.sh
@@ -2,9 +2,16 @@
 
 set -euo pipefail
 
+tag_search="${TAG_SEARCH_PREFIX}*"
 this_tag="${TAG_NAME/#refs\/tags\//}"
 
-recent_tags="$(git tag --sort=creatordate --list 'v*' | grep -P 'v\d+\.\d+\.\d+' | grep --color=no -B1 "^$this_tag\$")"
+tags_list="$(git tag --sort=creatordate --list "$tag_search")"
+if [[ "$TAG_SEARCH_REGEX" == "" ]]; then
+    filtered_tags_list="$tags_list"
+else
+    filtered_tags_list="$(echo "$tags_list" | grep -P "$TAG_SEARCH_REGEX")"
+fi
+recent_tags="$(echo "$filtered_tags_list" | grep --color=no -B1 "^$this_tag\$")"
 previous_tag="$(echo "$recent_tags" | head -n1)"
 
 previous_tag_date="$(git log -1 --no-walk --pretty="format:%cI" "$previous_tag")"
@@ -12,6 +19,9 @@ this_tag_date="$(git log -1 --no-walk --pretty="format:%cI" "$this_tag")"
 
 start_date="$(date -Is -d "$previous_tag_date")"
 end_date="$(date -Is -d "$this_tag_date")"
+
+echo "Previous tag: $previous_tag at $start_date"
+echo "This tag: $this_tag at $end_date"
 
 {
   echo "start_date=$start_date"


### PR DESCRIPTION
Some repositories may not use the tag format `vN.N.N`, so allow overriding tag filters