### PR TITLE
Setup Ruby action

### DIFF
--- a/.github/workflows/test_setup_ruby.yml
+++ b/.github/workflows/test_setup_ruby.yml
@@ -1,0 +1,43 @@
+name: Test setup-ruby
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  find_changes:
+    name: "Find changed directories"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
+      matrix_empty: ${{ steps.get-matrix.outputs.matrix_empty }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: get-matrix
+        uses: smartlyio/find-changes-action@v1
+        with:
+          directory_containing: action.yml
+
+  test:
+    name: setup-ruby ${{ matrix.os }}/${{ matrix.version }}/${{ matrix.bundler_cache }}
+    needs: find_changes
+    if: contains(fromJson(needs.find_changes.outputs.matrix).directory, 'setup-ruby')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12 ]
+        version: [ '2.7', '3.0', '3.1', '3.2' ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: _actions
+      - run: |
+          cp -R ./_actions/_testing/setup-ruby/* .
+      - uses: ./_actions/setup-ruby
+        with:
+          version: ${{ matrix.version }}
+          bundler_cache: 'true'

--- a/.github/workflows/test_setup_ruby.yml
+++ b/.github/workflows/test_setup_ruby.yml
@@ -22,7 +22,7 @@ jobs:
           directory_containing: action.yml
 
   test:
-    name: setup-ruby ${{ matrix.os }}/${{ matrix.version }}/${{ matrix.bundler_cache }}
+    name: setup-ruby ${{ matrix.os }}/${{ matrix.version }}
     needs: find_changes
     if: contains(fromJson(needs.find_changes.outputs.matrix).directory, 'setup-ruby')
     strategy:
@@ -39,5 +39,5 @@ jobs:
           cp -R ./_actions/_testing/setup-ruby/* .
       - uses: ./_actions/setup-ruby
         with:
-          version: ${{ matrix.version }}
+          ruby-version: ${{ matrix.version }}
           bundler_cache: 'true'

--- a/.github/workflows/test_setup_ruby.yml
+++ b/.github/workflows/test_setup_ruby.yml
@@ -42,23 +42,25 @@ jobs:
           ruby-version: ${{ matrix.version }}
           bundler-cache: 'true'
 
-  test-custom-wrapper:
-    name: setup-ruby (wrap) ${{ matrix.os }}/${{ matrix.version }}
-    needs: find_changes
-    if: contains(fromJson(needs.find_changes.outputs.matrix).directory, 'setup-ruby')
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ macos-11, macos-12 ]
-        version: [ '2.7', '3.0', '3.1', '3.2' ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          path: _actions
-      - run: |
-          cp -R ./_actions/_testing/setup-ruby/* .
-      - uses: ./_actions/setup-ruby
-        with:
-          ruby-version: ${{ matrix.version }}
-          force-custom-macos-install: 'true'
+  ### This test is commented out. GitHub runners will fail on installing ruby via brew
+  ### because of other broken dependencies in the brew update/upgrade process
+  #  test-custom-wrapper:
+  #    name: setup-ruby (wrap) ${{ matrix.os }}/${{ matrix.version }}
+  #    needs: find_changes
+  #    if: contains(fromJson(needs.find_changes.outputs.matrix).directory, 'setup-ruby')
+  #    strategy:
+  #      fail-fast: false
+  #      matrix:
+  #        os: [ macos-11, macos-12 ]
+  #        version: [ '2.7', '3.0', '3.1', '3.2' ]
+  #    runs-on: ${{ matrix.os }}
+  #    steps:
+  #      - uses: actions/checkout@v3
+  #        with:
+  #          path: _actions
+  #      - run: |
+  #          cp -R ./_actions/_testing/setup-ruby/* .
+  #      - uses: ./_actions/setup-ruby
+  #        with:
+  #          ruby-version: ${{ matrix.version }}
+  #          force-custom-macos-install: 'true'

--- a/.github/workflows/test_setup_ruby.yml
+++ b/.github/workflows/test_setup_ruby.yml
@@ -43,7 +43,7 @@ jobs:
           bundler-cache: 'true'
 
   test-custom-wrapper:
-    name: setup-ruby ${{ matrix.os }}/${{ matrix.version }}
+    name: setup-ruby (wrap) ${{ matrix.os }}/${{ matrix.version }}
     needs: find_changes
     if: contains(fromJson(needs.find_changes.outputs.matrix).directory, 'setup-ruby')
     strategy:

--- a/.github/workflows/test_setup_ruby.yml
+++ b/.github/workflows/test_setup_ruby.yml
@@ -41,3 +41,24 @@ jobs:
         with:
           ruby-version: ${{ matrix.version }}
           bundler-cache: 'true'
+
+  test-custom-wrapper:
+    name: setup-ruby ${{ matrix.os }}/${{ matrix.version }}
+    needs: find_changes
+    if: contains(fromJson(needs.find_changes.outputs.matrix).directory, 'setup-ruby')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-11, macos-12 ]
+        version: [ '2.7', '3.0', '3.1', '3.2' ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: _actions
+      - run: |
+          cp -R ./_actions/_testing/setup-ruby/* .
+      - uses: ./_actions/setup-ruby
+        with:
+          ruby-version: ${{ matrix.version }}
+          force-custom-macos-install: 'true'

--- a/.github/workflows/test_setup_ruby.yml
+++ b/.github/workflows/test_setup_ruby.yml
@@ -40,4 +40,4 @@ jobs:
       - uses: ./_actions/setup-ruby
         with:
           ruby-version: ${{ matrix.version }}
-          bundler_cache: 'true'
+          bundler-cache: 'true'

--- a/_testing/setup-ruby/Gemfile
+++ b/_testing/setup-ruby/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'octokit'

--- a/_testing/setup-ruby/Gemfile.lock
+++ b/_testing/setup-ruby/Gemfile.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    faraday (2.7.3)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    octokit (6.0.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    public_suffix (5.0.1)
+    ruby2_keywords (0.0.5)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  octokit
+
+BUNDLED WITH
+   2.3.21

--- a/setup-ruby/README.md
+++ b/setup-ruby/README.md
@@ -1,1 +1,0 @@
-Lots of inspiration from https://github.com/ruby/setup-ruby/blob/master/bundler.js

--- a/setup-ruby/README.md
+++ b/setup-ruby/README.md
@@ -1,0 +1,1 @@
+Lots of inspiration from https://github.com/ruby/setup-ruby/blob/master/bundler.js

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -47,7 +47,7 @@ runs:
         brew install ruby@${{ inputs.ruby-version }}
         BIN_PATH="$(brew --prefix ruby@${{ inputs.ruby-version }})"
         
-        export PATH="$BIN_PATH:$PATH
+        export PATH="$BIN_PATH:$PATH"
         echo "$BIN_PATH/bin" >> $GITHUB_PATH
         
         bundle install

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - run: |
         set -e
-        brew install ruby@${{ inputs.ruby-version }}
+        brew update && brew install ruby@${{ inputs.ruby-version }}
         BIN_PATH="$(brew --prefix ruby@${{ inputs.ruby-version }})"
         
         export PATH="$BIN_PATH:$PATH"

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -50,6 +50,10 @@ runs:
         export PATH="$BIN_PATH:$PATH"
         echo "$BIN_PATH/bin" >> $GITHUB_PATH
         
+        bundler_version=
+        [[ -f "Gemfile.lock" ]] && bundler_version="$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -n1 | xargs || true)"
+        [[ -n "$bundler_version" ]] && gem install "bundler:$bundler_version"
+        
         bundle install
       # the setup-ruby action does not support macos-13 yet
       shell: bash

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -37,7 +37,7 @@ runs:
   steps:
     - run: |
         echo "macos_version=$(sw_vers -productVersion | cut -f1 -d.)" >> "$GITHUB_OUTPUT"
-        echo "macos_arch=$(uname -p)"
+        echo "macos_arch=$(uname -p)" >> "$GITHUB_OUTPUT"
       shell: bash
       if: "${{ runner.os == 'macOS' }}"
       id: get_macos_version

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -4,7 +4,7 @@ description: |
   
   Supported platforms:
   
-  * Any MacOS X64/ARM machines with a simple brew install and NO cache support
+  * MacOS ARM and MacOS 13 machines with a simple brew install and NO cache support
   * All the other platforms supported by https://github.com/ruby/setup-ruby
 inputs:
   ruby-version:

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -62,7 +62,7 @@ runs:
       # the setup-ruby action does not support macos-13 yet
       shell: bash
       working-directory: "${{ inputs.working-directory }}"
-      if: "${{ inputs.force-custom-macos-install == 'true' || runner.os == 'macOS' && (steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version == '13') }}"
+      if: "${{ inputs.force-custom-macos-install == 'true' || (runner.os == 'macOS' && (steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version == '13')) }}"
 
     - uses: ruby/setup-ruby@v1
       if: "${{ inputs.force-custom-macos-install != 'true' && (runner.os != 'macOS' || steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version != '13') }}"

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -1,0 +1,66 @@
+name: Setup Ruby
+description: |
+  Sets up Ruby. Wrapper around https://github.com/ruby/setup-ruby
+  
+  Supported platforms:
+  
+  * macos-13 with a simple brew install and NO cache support
+  * All the other platforms supported by https://github.com/ruby/setup-ruby
+inputs:
+  ruby-version:
+    description: 'Engine and version to use, see the syntax in the README. Reads from .ruby-version or .tool-versions if unset.'
+    default: 'default'
+  rubygems:
+    description: |
+      The version of RubyGems to use. Either 'default' (the default), 'latest', or a version number (e.g., 3.3.5).
+      For 'default', no action is taken and the version of RubyGems that comes with Ruby by default is used.
+      For 'latest', `gem update --system` is run to update to the latest RubyGems version.
+      Similarly, if a version number is given, `gem update --system <version>` is run to update to that version of RubyGems, as long as that version is newer than the one provided by default.
+  bundler:
+    description: |
+      The version of Bundler to install. Either 'Gemfile.lock' (the default), 'default', 'latest', 'none', or a version number (e.g., 1, 2, 2.1, 2.1.4).
+      For 'Gemfile.lock', the version of the BUNDLED WITH section from the Gemfile.lock if it exists. If the file or section does not exist then the same as 'default'.
+      For 'default', if the Ruby ships with Bundler 2.2+ as a default gem, that version is used, otherwise the same as 'latest'.
+      For 'latest', the latest compatible Bundler version is installed (Bundler 2 on Ruby >= 2.3, Bundler 1 on Ruby < 2.3).
+      For 'none', nothing is done.
+  bundler-cache:
+    description: 'Run "bundle install", and cache the result automatically. Either true or false.'
+    default: 'false'
+  working-directory:
+    description: 'The working directory to use for resolving paths for .ruby-version, .tool-versions and Gemfile.lock.'
+  cache-version:
+    description: |
+      Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need
+      to invalidate the cache.
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        echo "macos_version=$(sw_vers -productVersion | cut -f1 -d.)" >> "$GITHUB_OUTPUT"
+      shell: bash
+      if: "${{ runner.os == 'macOS' }}"
+      id: get_macos_version
+
+    - run: |
+        set -e
+        brew install ruby@${{ inputs.ruby-version }}
+        BIN_PATH="$(brew --prefix ruby@${{ inputs.ruby-version }})"
+        
+        export PATH="$BIN_PATH:$PATH
+        echo "$BIN_PATH/bin" >> $GITHUB_PATH
+        
+        bundle install
+      # the setup-ruby action does not support macos-13 yet
+      shell: bash
+      working-directory: "${{ inputs.working-directory }}"
+      if: "${{ runner.os == 'macOS' && steps.get_macos_version.outputs.macos_version == '13' }}"
+
+    - uses: ruby/setup-ruby@v1
+      if: "${{ runner.os != 'macOS' || (runner.os == 'macOS' && steps.get_macos_version.outputs.macos_version != '13') }}"
+      with:
+        ruby-version: "${{ inputs.ruby-version }}"
+        bundler: "${{ inputs.bundler }}"
+        bundler-cache: "${{ inputs.bundler-cache }}"
+        rubygems: "${{ inputs.rubygems }}"
+        working-directory: "${{ inputs.working-directory }}"
+        cache-version: "${{ inputs.cache-version }}"

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -75,7 +75,7 @@ runs:
     - uses: ruby/setup-ruby@v1
       if: |
         inputs.force-custom-macos-install != 'true' && 
-          !(
+        !(
           runner.os == 'macOS' && 
           (
             steps.get_macos_version.outputs.macos_arch == 'arm' || 

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: |
       Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need
       to invalidate the cache.
+  force-custom-macos-install:
+    description: |
+      If true, forces the custom hack to install ruby via brew
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -58,10 +62,10 @@ runs:
       # the setup-ruby action does not support macos-13 yet
       shell: bash
       working-directory: "${{ inputs.working-directory }}"
-      if: "${{ runner.os == 'macOS' && (steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version == '13') }}"
+      if: "${{ inputs.force-custom-macos-install == 'true' || runner.os == 'macOS' && (steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version == '13') }}"
 
     - uses: ruby/setup-ruby@v1
-      if: "${{ runner.os != 'macOS' || steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version != '13' }}"
+      if: "${{ inputs.force-custom-macos-install != 'true' && (runner.os != 'macOS' || steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version != '13') }}"
       with:
         ruby-version: "${{ inputs.ruby-version }}"
         bundler: "${{ inputs.bundler }}"

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -51,7 +51,7 @@ runs:
         brew update && brew install ruby@${{ inputs.ruby-version }}
         BIN_PATH="$(brew --prefix ruby@${{ inputs.ruby-version }})"
         
-        export PATH="$BIN_PATH:$PATH"
+        export PATH="$BIN_PATH/bin:$PATH"
         echo "$BIN_PATH/bin" >> $GITHUB_PATH
         
         bundler_version=

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -37,6 +37,7 @@ runs:
   steps:
     - run: |
         echo "macos_version=$(sw_vers -productVersion | cut -f1 -d.)" >> "$GITHUB_OUTPUT"
+        echo "macos_arch=$(uname -p)"
       shell: bash
       if: "${{ runner.os == 'macOS' }}"
       id: get_macos_version
@@ -53,10 +54,10 @@ runs:
       # the setup-ruby action does not support macos-13 yet
       shell: bash
       working-directory: "${{ inputs.working-directory }}"
-      if: "${{ runner.os == 'macOS' && steps.get_macos_version.outputs.macos_version == '13' }}"
+      if: "${{ runner.os == 'macOS' && (steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version == '13') }}"
 
     - uses: ruby/setup-ruby@v1
-      if: "${{ runner.os != 'macOS' || (runner.os == 'macOS' && steps.get_macos_version.outputs.macos_version != '13') }}"
+      if: "${{ runner.os != 'macOS' || steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version != '13' }}"
       with:
         ruby-version: "${{ inputs.ruby-version }}"
         bundler: "${{ inputs.bundler }}"

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -62,10 +62,26 @@ runs:
       # the setup-ruby action does not support macos-13 yet
       shell: bash
       working-directory: "${{ inputs.working-directory }}"
-      if: "${{ inputs.force-custom-macos-install == 'true' || (runner.os == 'macOS' && (steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version == '13')) }}"
+      if: |
+        inputs.force-custom-macos-install == 'true' || 
+        (
+          runner.os == 'macOS' && 
+          (
+            steps.get_macos_version.outputs.macos_arch == 'arm' || 
+            steps.get_macos_version.outputs.macos_version == '13'
+          )
+        )
 
     - uses: ruby/setup-ruby@v1
-      if: "${{ inputs.force-custom-macos-install != 'true' && (runner.os != 'macOS' || steps.get_macos_version.outputs.macos_arch == 'arm' || steps.get_macos_version.outputs.macos_version != '13') }}"
+      if: |
+        inputs.force-custom-macos-install != 'true' && 
+          !(
+          runner.os == 'macOS' && 
+          (
+            steps.get_macos_version.outputs.macos_arch == 'arm' || 
+            steps.get_macos_version.outputs.macos_version == '13'
+          )
+        )
       with:
         ruby-version: "${{ inputs.ruby-version }}"
         bundler: "${{ inputs.bundler }}"

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -4,7 +4,7 @@ description: |
   
   Supported platforms:
   
-  * macos-13 with a simple brew install and NO cache support
+  * Any MacOS X64/ARM machines with a simple brew install and NO cache support
   * All the other platforms supported by https://github.com/ruby/setup-ruby
 inputs:
   ruby-version:


### PR DESCRIPTION
This is a wrapper action to setup Ruby.

A custom installer will run in case the runners are one of the following:

* macos-13
* ARM nodes

Currently only supports self-hosted MacOS runners with normal Homebrew installations