### PR TITLE
Create new action for simply creating a release object in github

### DIFF
--- a/create-simple-github-release/action.yml
+++ b/create-simple-github-release/action.yml
@@ -1,0 +1,29 @@
+name: Create simple GitHub release
+description: Create a GitHub release with the specified tag, name and body
+inputs:
+  token:
+    description: 'A Github PAT'
+    required: true
+  tag-name:
+    description: 'Name of the tag being released'
+    required: false
+    default: ${{ github.ref }}
+  release-name:
+    description: 'Name of the release being created'
+    required: false
+    default: ${{ github.ref }}
+  release-body:
+    description: 'Content of the release description'
+    required: false
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - name: Create Release
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        TAG_NAME: ${{ inputs.tag-name }}
+        RELEASE_NAME: ${{ inputs.release-name }}
+        RELEASE_BODY: ${{ inputs.release-body }}
+      run: ${{ github.action_path }}/create-release.sh
+      shell: bash

--- a/create-simple-github-release/create-release.sh
+++ b/create-simple-github-release/create-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck disable=SC2153
+tag_name="${TAG_NAME/#refs\/tags\//}"
+# shellcheck disable=SC2153
+release_name="${RELEASE_NAME/#refs\/tags\//}"
+# shellcheck disable=SC2016
+JQ_FILTER='{
+  "tag_name": $tag_name,
+  "name": $release_name,
+  "body": $body,
+  "draft": false,
+  "prerelease": false
+}'
+RELEASE_SPEC="$(jq -c -n --arg body "$RELEASE_BODY" --arg tag_name "$tag_name" --arg release_name "$release_name" "$JQ_FILTER")"
+
+echo "Creating release:"
+echo "$RELEASE_SPEC" | jq .
+
+echo "Checking for existing release"
+if response="$(curl -f \
+     -H "Content-Type: application/json" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer $GITHUB_TOKEN" \
+     "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$tag_name")"; then
+    body_matches="$(echo "$response" | jq --arg body "$RELEASE_BODY" -r '.body == $body')"
+    if [[ "$body_matches" == "true" ]]; then
+        echo "Release already exists with the same content"
+        exit 0
+    else
+        echo -e "Release already exists with a different description:\n\n"
+        echo "$response" | jq .
+        exit 1
+    fi
+fi
+
+if ! response="$(curl -f \
+     -H "Content-Type: application/json" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer $GITHUB_TOKEN" \
+     -d "$RELEASE_SPEC" \
+     "https://api.github.com/repos/$GITHUB_REPOSITORY/releases")"; then
+    echo "Failed to create release:"
+    echo "$response"
+    exit 1
+else
+    echo "$response" | jq -r '"Created release " + .name + " on " + .target_commitish + "\n\n" + .body'
+fi


### PR DESCRIPTION
Content copied from `create-github-release`, which will be cleaned up to use this new action in a separate step.