### PR TITLE
feat: new action publish-confluence

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [`kube-check-krane-manifests`](./kube-check-krane-manifests/action.yml): Runs a fake krane deploy to validate kubernetes resources definitions.
 * [`release-action-node`](./release-action-node/action.yml): Releases a node.js action.
 * [`setup-ruby`](./setup-ruby/action.yml): Sets up Ruby. A wrapper around https://github.com/ruby/setup-ruby to also support `macos-13` runners.
+* [`publish-confluence`](./publish-confluence/action.yml): Fork of [markdown-confluence action](https://github.com/markdown-confluence/publish-action/) but with stricter docker image tag
 
 ## Release flow
 

--- a/publish-confluence/Dockerfile
+++ b/publish-confluence/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/markdown-confluence/publish:5.4.0
+
+USER root

--- a/publish-confluence/LICENSE
+++ b/publish-confluence/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/publish-confluence/README.md
+++ b/publish-confluence/README.md
@@ -1,0 +1,195 @@
+# markdown-confluence/publish GitHub Action
+
+This GitHub Action wraps up an NPM CLI that allows you to publish your Markdown files to Confluence quickly and easily. By using this action in your workflows, you can automate the process of publishing documentation to Confluence, making it faster, more streamlined, and more efficient.
+
+## Usage
+
+To use this GitHub Action in your repository, you'll need to create a workflow file (e.g., `.github/workflows/publish.yml`) and configure the action as described below.
+
+### Basic example
+
+```yaml
+name: Publish to Confluence
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Publish Markdown to Confluence
+        uses: markdown-confluence/publish@v1
+        with:
+          confluenceBaseUrl: https://your-confluence-instance-url
+          confluenceParentId: 123456
+          atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
+          atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+```
+
+### Example using a config file
+
+Create a `.markdown-confluence.json` file in your repository with the following content:
+
+```json
+{
+  "confluenceBaseUrl": "https://your-confluence-instance-url",
+  "confluenceParentId": "123456",
+  "atlassianUserName": "your-email@example.com",
+  "folderToPublish": "docs",
+  "contentRoot": "/docs"
+}
+```
+
+Then configure the GitHub Action in your workflow file:
+
+```yaml
+name: Publish to Confluence
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Publish Markdown to Confluence
+        uses: markdown-confluence/publish@v1
+        with:
+          configFile: .markdown-confluence.json
+          atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+```
+
+
+## Input Options
+
+This section provides an overview of all the input options available for the `markdown-confluence/publish` GitHub Action and examples of how to use them in your workflows.
+
+### confluenceBaseUrl
+
+The base URL of your Confluence instance, used for API calls and publishing content. This value should include the protocol (e.g., `https://`) but not a trailing slash.
+
+Example:
+
+```yaml
+with:
+  confluenceBaseUrl: https://your-confluence-instance-url
+```
+
+### confluenceParentId
+
+The ID of the parent page in Confluence where the Markdown files will be published as child pages.
+
+Example:
+
+```yaml
+with:
+  confluenceParentId: 123456
+```
+
+### atlassianUserName
+
+Your Atlassian account's username, required for authentication when interacting with Confluence.
+
+Example:
+
+```yaml
+with:
+  atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
+```
+
+### atlassianApiToken
+
+An API token generated for your Atlassian account, used for authentication when making API calls to Confluence. This value should be stored as a repository secret.
+
+Example:
+
+```yaml
+with:
+  atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+```
+
+### folderToPublish
+
+The folder you want to apply a default of "connie-publish: true" to. All Markdown files within this folder will be considered for publishing.
+
+Example:
+
+```yaml
+with:
+  folderToPublish: docs
+```
+
+### contentRoot
+
+The root path for published content on Confluence. This is used to tell the action where to look for Markdown files and content.
+
+Example:
+
+```yaml
+with:
+  contentRoot: /docs
+```
+
+### configFile
+
+A configuration file containing additional settings and customizations for the publishing process. You can use this option to keep your workflow file clean and maintain all configuration settings in a separate file.
+
+Example:
+
+```yaml
+with:
+  configFile: .markdown-confluence.json
+```
+
+## Advanced Example
+
+Here's an example of using all input options in a single workflow:
+
+```yaml
+name: Publish to Confluence
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Publish Markdown to Confluence
+        uses: markdown-confluence/publish@v1
+        with:
+          confluenceBaseUrl: https://your-confluence-instance-url
+          confluenceParentId: 123456
+          atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
+          atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+          folderToPublish: docs
+          contentRoot: /docs
+          configFile: .markdown-confluence.json
+```
+
+Remember to create and configure the `.markdown-confluence.json` file in your repository as needed.
+
+### Storing API token as a repository secret
+
+To store your Atlassian API token as a repository secret, follow these steps:
+
+1. Go to your GitHub repository and click on the "Settings" tab.
+2. In the left sidebar, click on "Secrets".
+3. Click on the "New repository secret" button.
+4. Enter `ATLASSIAN_API_TOKEN` as the name and paste your API token as the value.
+5. Click on the "Add secret" button.
+
+Now you can reference the `ATLASSIAN_API_TOKEN` secret in your GitHub Actions workflows using the syntax `${{ secrets.ATLASSIAN_API_TOKEN }}`.
+
+
+## Support
+
+If you need help with using this action or encounter any issues, please open an issue in the [GitHub repository](https://github.com/markdown-confluence/markdown-confluence/issues).
+
+## License
+
+This GitHub Action is released under the Apache 2.0 License.

--- a/publish-confluence/action.yml
+++ b/publish-confluence/action.yml
@@ -1,0 +1,31 @@
+name: 'markdown-confluence'
+description: 'Publish Markdown files to Confluence'
+branding:
+  icon: 'file-text'
+  color: 'green'
+inputs:
+  confluenceBaseUrl:
+    description: 'The base URL of your Confluence instance, used for API calls and publishing content.'
+  confluenceParentId:
+    description: 'The ID of the parent page in Confluence where the Markdown files will be published as child pages.'
+  atlassianUserName:
+    description: 'Your Atlassian account''s username, required for authentication when interacting with Confluence.'
+  atlassianApiToken:
+    description: 'An API token generated for your Atlassian account, used for authentication when making API calls to Confluence.'
+  folderToPublish:
+    description: 'The folder you want to apply a default of "connie-publish: true" to.'
+  contentRoot:
+    description: 'The root path for published content on Confluence. This is used to tell the action where to look for Markdown files and content.'
+  configFile:
+    description: 'A configuration file containing additional settings and customizations for the publishing process.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    CONFLUENCE_BASE_URL: ${{ inputs.confluenceBaseUrl }}
+    CONFLUENCE_PARENT_ID: ${{ inputs.confluenceParentId }}
+    ATLASSIAN_USERNAME: ${{ inputs.atlassianUserName }}
+    ATLASSIAN_API_TOKEN: ${{ inputs.atlassianApiToken }}
+    FOLDER_TO_PUBLISH: ${{ inputs.folderToPublish }}
+    CONFLUENCE_CONTENT_ROOT: ${{ inputs.contentRoot }}
+    CONFLUENCE_CONFIG_FILE: ${{ inputs.configFile }}


### PR DESCRIPTION
Fork of public action https://github.com/markdown-confluence/publish-action/ as the dockerfile on that one just points to the `5` tag which changes on a new release, breaking reproducability.

The action is licensed under Apache 2.0 so I included the original LICENSE here, though the creater hasn't changed the year or author name...