### PR TITLE
Publish confluence

### DIFF
--- a/publish-confluence/Dockerfile
+++ b/publish-confluence/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/markdown-confluence/publish:5.4.0
+FROM ghcr.io/markdown-confluence/publish:v5.4.0
 
 USER root

--- a/publish-confluence/action.yml
+++ b/publish-confluence/action.yml
@@ -29,3 +29,4 @@ runs:
     FOLDER_TO_PUBLISH: ${{ inputs.folderToPublish }}
     CONFLUENCE_CONTENT_ROOT: ${{ inputs.contentRoot }}
     CONFLUENCE_CONFIG_FILE: ${{ inputs.configFile }}
+    CONFLUENCE_FIRST_HEADING_PAGE_TITLE: ${{ inputs.firstHeadingPageTitle }}


### PR DESCRIPTION
Had mistakenly used tag `5.4.0` and not `v5.4.0` so it didn't work. Now actually verified with `docker build .` and it works.

Additionally expose a new config option as an action input that the original creator probably forgot to do. 