### PR TITLE
VULCAN-3443: Add PR checklist

### DIFF
--- a/.github/workflows/test_add-pr-checklist.yml
+++ b/.github/workflows/test_add-pr-checklist.yml
@@ -1,0 +1,20 @@
+name: Test add-pr-checklist
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - add-pr-checklist/**
+
+jobs:
+  test:
+    name: add-pr-checklist
+    runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./add-pr-checklist
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          checklist_file: _testing/add-pr-checklist/PR_CHECKLIST.md

--- a/.github/workflows/test_add-pr-checklist.yml
+++ b/.github/workflows/test_add-pr-checklist.yml
@@ -17,4 +17,5 @@ jobs:
       - uses: ./add-pr-checklist
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          checklist_file: _testing/add-pr-checklist/PR_CHECKLIST.md
+          # Uncomment to test a custom path
+          # checklist_file: _testing/add-pr-checklist/PR_CHECKLIST.md

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 * [`action-monorepo-promote`](./action-monorepo-promote/action.yml): Given a monorepo composed of multiple action folders, deletes all other actions and moves all the
   contents of the main action to the root of the repo.
 * [`auto-tagger`](./auto-tagger/action.yml): Creates a new version (tag+branch) for a repository based on the labels "major, minor, patch" associated with the current pull-request.
+* [`add-pr-checklist`](./add-pr-checklist/action.yml): Adds a reviewer checklist comment to a PR.
 * [`calculate-incremental-tag`](./calculate-incremental-tag/action.yml): Action to calculate a lightweight incremental tag.
 * [`check-branch-behind`](./check-branch-behind/action.yml): Checks if the current revision is at head of the default branch.
 * [`create-github-release`](./create-github-release/action.yml) Create a new GitHub tag and release, with a semantic version bump based on PR labels.

--- a/_testing/add-pr-checklist/PR_CHECKLIST.md
+++ b/_testing/add-pr-checklist/PR_CHECKLIST.md
@@ -1,0 +1,1 @@
+Hello world!

--- a/add-pr-checklist/action.yml
+++ b/add-pr-checklist/action.yml
@@ -1,0 +1,34 @@
+name: Add PR checklist
+description: |
+  Creates a pinned comment in a PR that contains a list of checklist items for reviewers to follow.
+inputs:
+  github_token:
+    description: 'A Github PAT'
+    required: true
+  checklist_file:
+    description: 'The template file containing the checklist contents'
+    default: PR_CHECKLIST.md
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: Check if there is already a PR checklist comment
+      id: find_pr_checklist_comment
+      uses: actions/github-script@v6
+      with:
+        script: return require('${{ github.action_path }}/scripts/check_pr_comment.js')({github, context})
+        github-token: ${{ inputs.github_token }}
+    - name: Load checklist content
+      id: load_pr_checklist
+      run: "${{ github.action_path }}/scripts/load_pr_checklist.sh"
+      shell: bash
+      if: steps.find_pr_checklist_comment.outputs.result == 'null'
+      env:
+        CHECKLIST_FILE: ${{ inputs.checklist_file }}
+    - uses: mshick/add-pr-comment@v2
+      if: steps.find_pr_checklist_comment.outputs.result == 'null'
+      with:
+        message-id: pr_checklist
+        message-path: ${{ steps.load_pr_checklist.outputs.checklist_file }}
+        repo-token: ${{ inputs.github_token }}

--- a/add-pr-checklist/assets/PR_CHECKLIST.md
+++ b/add-pr-checklist/assets/PR_CHECKLIST.md
@@ -1,0 +1,13 @@
+* [ ] **Functionality**: Does the code behave as the author likely intended? Does the behavior match the story/issue plan? If not, is the way the code behaves good for its users?
+* [ ] **Design**: Is the code well-designed and appropriate for your system?
+* [ ] **Complexity**: Could the code be made simpler? Would another developer be able to easily understand and use this code when they come across it in the future?
+* [ ] **Tests**: Does the code have correct and well-designed automated tests? Do tests cover the functionality in the pull request?
+  * If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
+  * Does the test actually test the new/changed functionality?
+  * Does the test successfully test edge cases?
+  * Does the test successfully test corner cases?
+* [ ] **Naming**: Did the developer choose clear names for variables, functions, classes, methods, etc.?
+* [ ] **Comments**: Are the comments clear and useful?
+* [ ] **Style**: The programming style meet the requirements of the repository
+* [ ] **Documentation**: Did the developer also update relevant documentation?
+* [ ] **Rollback**: Is the rollback plan sound?

--- a/add-pr-checklist/assets/PR_CHECKLIST.md
+++ b/add-pr-checklist/assets/PR_CHECKLIST.md
@@ -1,3 +1,5 @@
+For reviewers, please remember to check the following entries while looking at this PR:
+ 
 * [ ] **Functionality**: Does the code behave as the author likely intended? Does the behavior match the story/issue plan? If not, is the way the code behaves good for its users?
 * [ ] **Design**: Is the code well-designed and appropriate for your system?
 * [ ] **Complexity**: Could the code be made simpler? Would another developer be able to easily understand and use this code when they come across it in the future?

--- a/add-pr-checklist/scripts/check_pr_comment.js
+++ b/add-pr-checklist/scripts/check_pr_comment.js
@@ -1,0 +1,24 @@
+// https://github.com/actions/github-script
+
+module.exports = async ({github, context}) => {
+    // https://octokit.github.io/rest.js/v20#issues-list-comments
+    // https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#list-issue-comments
+
+    // No need to paginate, if there is a comment it will be near the top
+    const {data: comments} = await github.rest.issues.listComments({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+    });
+
+    const prComment = comments.find((c) => c.body.includes('<!-- add-pr-comment:pr_checklist -->'))
+
+    if (prComment == null) {
+        console.log('PR checklist comment not found')
+        return null
+    }
+
+    console.log('PR checklist comment found', {prComment})
+
+    return prComment.id
+}

--- a/add-pr-checklist/scripts/load_pr_checklist.sh
+++ b/add-pr-checklist/scripts/load_pr_checklist.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(dirname "$(readlink -f "$0")")"
+
+CHECKLIST_FILE="${CHECKLIST_FILE:-}"
+
+DEFAULT_CHECKLIST_FILE="$(readlink -f "$DIR/../assets/PR_CHECKLIST.md")"
+
+if [[ -z "$CHECKLIST_FILE" ]] || [[ ! -f "$CHECKLIST_FILE" ]]; then
+  # Use default file
+  echo "Using default checklist file: $DEFAULT_CHECKLIST_FILE"
+  echo "checklist_file=$DEFAULT_CHECKLIST_FILE" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+CHECKLIST_FILE="$(readlink -f "$CHECKLIST_FILE")"
+echo "Using custom checklist file: $CHECKLIST_FILE"
+echo "checklist_file=$CHECKLIST_FILE" >> "$GITHUB_OUTPUT"
+
+# BUMP


### PR DESCRIPTION
Adds the `add-pr-checklist` action.

This action will add a comment to the PR it's added to, using the content of the first of the follow sources to resolve, in order of priority:

* `input.checklist_file`, defaults to a `PR_CHECKLIST.md` file placed in the repository's root folder.
* Default checklist file (`add-pr-checklist/assets/PR_CHECKLIST.md`)

The comment will NOT be overwritten once it's been created, which will allow reviewers to tick the checkboxes.
