### PR TITLE
Use tr to lowercase string instead of builtin bash

### DIFF
--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -58,7 +58,9 @@ runs:
         [[ -f "Gemfile.lock" ]] && bundler_version="$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -n1 | xargs || true)"
         [[ -n "$bundler_version" ]] && gem install "bundler:$bundler_version"
 
-        if [[ "${RUN_BUNDLE_INSTALL,,}" == "true" ]]; then
+        run_bundle_install_lower="$(echo "$RUN_BUNDLE_INSTALL" | tr '[:upper:]' '[:lower:]')"
+
+        if [[ "$run_bundle_install_lower" == "true" ]]; then
           bundle install
         fi
       # the setup-ruby action does not support macos-13 yet


### PR DESCRIPTION
```
/Users/runner/work/_temp/651296d2-4d3b-49bf-a114-eee894127a87.sh: line 12: ${RUN_BUNDLE_INSTALL,,}: bad substitution
```

bash3 still in use on macos doesn't implement the syntax for lowercasing a string.

Replace with `tr`