### PR TITLE
Use homebrew hack only for osx 14

### DIFF
--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -74,7 +74,7 @@ runs:
           runner.os == 'macOS' && 
           (
             steps.get_macos_version.outputs.macos_arch == 'arm' || 
-            steps.get_macos_version.outputs.macos_version == '13'
+            steps.get_macos_version.outputs.macos_version == '14'
           )
         )
 
@@ -85,7 +85,7 @@ runs:
           runner.os == 'macOS' && 
           (
             steps.get_macos_version.outputs.macos_arch == 'arm' || 
-            steps.get_macos_version.outputs.macos_version == '13'
+            steps.get_macos_version.outputs.macos_version == '14'
           )
         )
       with:


### PR DESCRIPTION
osx 13 works normally with `ruby/setup-ruby` but for 14 we now need a workaround