### PR TITLE
Release action node logic

### DIFF
--- a/release-action-node/action.yml
+++ b/release-action-node/action.yml
@@ -39,7 +39,7 @@ runs:
       id: check_branch_behind
       uses: "smartlyio/github-actions@check-branch-behind-v1"
       with:
-        is_base_ref: true
+        is_base_ref: ${{ !inputs.dry_run }}
         remote_update: true
         git_default_branch: "${{ steps.get_base_branch.outputs.git_base_branch }}"
     - name: Create release

--- a/release-action-node/node-version.sh
+++ b/release-action-node/node-version.sh
@@ -2,9 +2,21 @@
 
 set -euo pipefail
 
-RUNS_USING="$(yq -r '.runs.using' < action.yml)"
-if ! echo "$RUNS_USING" | grep '^node[[:digit:]]\+' 1>/dev/null; then
+if [ -f action.yml ]; then
+  RUNS_USING="$(yq -r '.runs.using' < action.yml)"
+  if ! echo "$RUNS_USING" | grep '^node[[:digit:]]\+' 1>/dev/null; then
     echo "Unable to determine node version from action.yaml runs.using: $RUNS_USING"
     exit 1
+  fi
+  echo node-version="${RUNS_USING/node/}.x" >> "$GITHUB_OUTPUT"
+elif [ -f .node-version ]; then
+  NODE_VERSION="$(cat .node-version)"
+  if [[ $NODE_VERSION =~ '^[0-9]+\.[0-9]+\.[0-9]+$' ]]; then
+    echo "Unable to determine node version from .node-version: $NODE_VERSION"
+    exit 1
+  fi
+  echo node-version="${NODE_VERSION}" >> "$GITHUB_OUTPUT"
+else
+  echo "Directory does not contain neither action.yml nor .node-version file"
+  exit 1
 fi
-echo node-version="${RUNS_USING/node/}.x" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
There are two action improvements in this PR:
1. Fixing `dry_run` option which does not work for typescript action pull requests because it checks we are on the main branch
2. Adding and option to read node version from `.node-version` file if `action.yml` does not exist. This can happen in small action monorepos where we do not have `action.yml` in the root directory