### PR TITLE
Fix release-action-node dry run failures due to bad && pipelines

### DIFF
--- a/release-action-node/create-release.sh
+++ b/release-action-node/create-release.sh
@@ -9,4 +9,8 @@ else
   npm install
   npm version "$VERSION"
 fi
-[[ "${DRY_RUN,,}" == "false" ]] && git push && git push --tags
+if [[ "${DRY_RUN,,}" == "false" ]]; then
+    git push && git push --tags
+else
+    echo "[dry run] Push new version" 1>&2
+fi

--- a/release-action-node/update-release-branch.sh
+++ b/release-action-node/update-release-branch.sh
@@ -6,4 +6,8 @@ set -euo pipefail
 package_version="$(jq -r .version < package.json)"
 release_branch="v${package_version//.*/}"
 git checkout -b "${release_branch}"
-[[ "${DRY_RUN,,}" == "false" ]] && git push -u origin "${release_branch}"
+if [[ "${DRY_RUN,,}" == "false" ]]; then
+    git push -u origin "${release_branch}"
+else
+    echo "[dry run] Push changes to ${release_branch}" 1>&2
+fi

--- a/release-action-node/update-without-release.sh
+++ b/release-action-node/update-without-release.sh
@@ -13,5 +13,9 @@ git_changes="$(git status --porcelain -- dist || true)"
 if [ -n "$git_changes" ]; then
     git add -- dist
     git commit -m "Update compiled action"
-    [[ "${DRY_RUN,,}" == "false" ]] && git push
+    if [[ "${DRY_RUN,,}" == "false" ]]; then
+        git push
+    else
+        echo "[dry run] Push changes" 1>&2
+    fi
 fi


### PR DESCRIPTION
Chaining `[[ "$dry_run" == "false" ]] && do something` always fails when dry_run is `true`, because the conditional returns `1`, causing the entire action to fail under dry-run