### PR TITLE
Update find-changes-action to v2

### DIFF
--- a/.github/workflows/auto_tagger.yml
+++ b/.github/workflows/auto_tagger.yml
@@ -1,9 +1,12 @@
 name: Auto tag new actions
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
-    branches: [master]
-    types: [opened, synchronize, reopened, closed]
+    branches:
+      - master
 
 jobs:
   find_changes:
@@ -18,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: get-matrix
-        uses: smartlyio/find-changes-action@v1
+        uses: smartlyio/find-changes-action@v2
         with:
           directory_containing: action.yml
 
@@ -64,3 +67,4 @@ jobs:
           tag_prefix: "${{ matrix.directory }}-"
           force_push: "true"
           commit_latest: "Promoted action ${{ matrix.directory }}"
+          auto_tag_always: ${{ github.event_name == 'push' }}

--- a/.github/workflows/auto_tagger.yml
+++ b/.github/workflows/auto_tagger.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   find_changes:
     name: "Find changed directories that need tagging"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
       matrix_empty: ${{ steps.get-matrix.outputs.matrix_empty }}
@@ -26,7 +26,7 @@ jobs:
 
   create_tag:
     name: "Create tags"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: find_changes
     if: needs.find_changes.outputs.matrix_empty == 'false'
     strategy:

--- a/.github/workflows/auto_tagger.yml
+++ b/.github/workflows/auto_tagger.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   find_changes:
     name: "Find changed directories that need tagging"
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -29,7 +28,7 @@ jobs:
     name: "Create tags"
     runs-on: ubuntu-20.04
     needs: find_changes
-    if: needs.find_changes.outputs.matrix_empty == 'false' && github.event_name == 'pull_request'
+    if: needs.find_changes.outputs.matrix_empty == 'false'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/auto_tagger.yml
+++ b/.github/workflows/auto_tagger.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
       matrix_empty: ${{ steps.get-matrix.outputs.matrix_empty }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: get-matrix
@@ -35,7 +35,7 @@ jobs:
         directory: ${{ fromJson(needs.find_changes.outputs.matrix).directory }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test_calculate_incremental_tag.yml
+++ b/.github/workflows/test_calculate_incremental_tag.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: calculate-incremental-tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - id: create_tag

--- a/.github/workflows/test_calculate_incremental_tag.yml
+++ b/.github/workflows/test_calculate_incremental_tag.yml
@@ -11,7 +11,7 @@ jobs:
     name: calculate-incremental-tag
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: create_tag
         uses: ./calculate-incremental-tag
       - run: |

--- a/.github/workflows/test_setup_ruby.yml
+++ b/.github/workflows/test_setup_ruby.yml
@@ -17,7 +17,7 @@ jobs:
         version: [ '2.7', '3.0', '3.1', '3.2' ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: _actions
       - run: |
@@ -38,7 +38,7 @@ jobs:
   #        version: [ '2.7', '3.0', '3.1', '3.2' ]
   #    runs-on: ${{ matrix.os }}
   #    steps:
-  #      - uses: actions/checkout@v3
+  #      - uses: actions/checkout@v4
   #        with:
   #          path: _actions
   #      - run: |

--- a/publish-confluence/README.md
+++ b/publish-confluence/README.md
@@ -14,7 +14,7 @@ on: push
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ on: push
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -154,7 +154,7 @@ on: push
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/publish-confluence/README.md
+++ b/publish-confluence/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - name: Publish Markdown to Confluence
         uses: markdown-confluence/publish@v1
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - name: Publish Markdown to Confluence
         uses: markdown-confluence/publish@v1
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - name: Publish Markdown to Confluence
         uses: markdown-confluence/publish@v1


### PR DESCRIPTION
# What

Title. Also updated set ubuntu versions to 22.04 and updated checkout action to v4.

# Why

\+ simpler workflow (no longer re-defining the default types of pull_request + adding closed and some ifs as a workaround for running the workflow on merge)
\+ merge workflow runs visible in default branch history