### PR TITLE
Support non-action releases with release-action-node

### DIFF
--- a/release-action-node/action.yml
+++ b/release-action-node/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Set to false for non-action releases"
     required: false
     default: "true"
+outputs:
+  result:
+    description: "Reports whether release was cancelled or skipped"
+    value: ${{ steps.notify_status.outputs.status }}
 runs:
   using: "composite"
   steps:
@@ -70,3 +74,12 @@ runs:
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         "$GITHUB_ACTION_PATH/update-release-branch.sh"
+    - name: Set job result
+      id: notify_status
+      if: steps.check_branch_behind.outputs.branch_up_to_date == 'false' || 'steps.version_check.outputs.continue_release' == 'false'
+      shell: bash
+      env:
+        CONTINUE_RELEASE: ${{ steps.version_check.outputs.continue_release }}
+        BRANCH_UP_TO_DATE: ${{ steps.check_branch_behind.outputs.branch_up_to_date }}
+      run: |
+        "$GITHUB_ACTION_PATH/notify-status.sh"

--- a/release-action-node/action.yml
+++ b/release-action-node/action.yml
@@ -2,14 +2,14 @@ name: Release action (node.js)
 description: Releases a node.js action.
 inputs:
   token:
-    description: 'A Github PAT'
+    description: "A Github PAT"
     required: true
   dry_run:
-    description: 'True to not commit anything'
+    description: "True to not commit anything"
     required: false
     default: "false"
   use_yarn:
-    description: 'If true, uses yarn instead of npm'
+    description: "If true, uses yarn instead of npm"
     required: false
     default: "false"
 runs:

--- a/release-action-node/action.yml
+++ b/release-action-node/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "If true, uses yarn instead of npm"
     required: false
     default: "false"
+  update_release_branch:
+    description: "Set to false for non-action releases"
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -60,7 +64,7 @@ runs:
       run: |
         "$GITHUB_ACTION_PATH/update-without-release.sh"
     - name: Update release branch
-      if: steps.check_branch_behind.outputs.branch_up_to_date == 'true' && steps.version_check.outputs.continue_release == 'true'
+      if: steps.check_branch_behind.outputs.branch_up_to_date == 'true' && steps.version_check.outputs.continue_release == 'true' && inputs.update_release_branch == 'true'
       shell: bash
       env:
         DRY_RUN: ${{ inputs.dry_run }}

--- a/release-action-node/notify-status.sh
+++ b/release-action-node/notify-status.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${CONTINUE_RELEASE,,}" == "false" ]]; then
+  echo status=cancelled >> "$GITHUB_OUTPUT"
+elif [[ "${BRANCH_UP_TO_DATE,,}" == "false" ]]; then
+  echo status=skipped >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
# Why

To be able to use this in a service.

## Concern

The action name no longer matches what it does if its use is expanded outside action releases. But I don't think releasing a separate action (`release-node`?) is desirable either as the resulting action would be very similar to this one, creating an unnecessary maintenance burden. Can always be split later.

