### PR TITLE
`publish-confluence`: Add missing input to fix IDE warning

### DIFF
--- a/publish-confluence/action.yml
+++ b/publish-confluence/action.yml
@@ -18,6 +18,8 @@ inputs:
     description: 'The root path for published content on Confluence. This is used to tell the action where to look for Markdown files and content.'
   configFile:
     description: 'A configuration file containing additional settings and customizations for the publishing process.'
+  firstHeadingPageTitle:
+    description: 'true/false, whether first heading should be used as page title.'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
In MCLB one gets this annoying red line from the GitHub Actions extension due to the input not being defined.

![image](https://github.com/user-attachments/assets/cffbdc7f-51b7-4bff-9a6e-9c9d5ff8074c)

The input is already used in the action.yml on [line 32](https://github.com/smartlyio/github-actions/blob/publish-confluence-v1/action.yml#L32).