### PR TITLE
Filter out the last merge commit from results for next version search

### DIFF
--- a/get-next-semantic-version/action.yml
+++ b/get-next-semantic-version/action.yml
@@ -41,6 +41,7 @@ runs:
           echo "last_tag=$last_tag"
           echo "last_tag_commit=$last_tag_commit"
         } >> "$GITHUB_OUTPUT"
+        cat "$GITHUB_OUTPUT"
     - name: Get PR labels
       uses: octokit/graphql-action@v2.x
       id: get_latest_prs
@@ -58,6 +59,9 @@ runs:
                         name
                       }
                     }
+                    mergeCommit {
+                      oid
+                    }
                   }
                 }
               }
@@ -70,19 +74,10 @@ runs:
       id: version_check
       env:
         PR_DATA: "${{ steps.get_latest_prs.outputs.data }}"
+        LAST_TAG_COMMIT: "${{ steps.tag_info.outputs.last_tag_commit }}"
       shell: bash
       run: |
-        echo "$PR_DATA"
-        version=$(echo "$PR_DATA" | grep -m1 -oi major || echo "$PR_DATA" | grep -m1 -oi minor || echo "$PR_DATA" | grep -m1 -oi patch || echo "")
-        version_lower="${version,,}"
-        {
-          echo "version=$version_lower"
-          if [ -z "$version" ]; then
-            echo "continue_release=false"
-          else
-            echo "continue_release=true"
-          fi
-        } >> "$GITHUB_OUTPUT"
+        "${GITHUB_ACTION_PATH}/process-latest-prs.sh"
     - name: Show version being bumped
       if: steps.version_check.outputs.continue_release == 'true'
       shell: bash
@@ -97,3 +92,4 @@ runs:
       run: |
         NEXT_VERSION="$("${GITHUB_ACTION_PATH}/calculate-version.sh" "$BUMP" "$PREVIOUS_VERSION")"
         echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+        cat "$GITHUB_OUTPUT"

--- a/get-next-semantic-version/process-latest-prs.sh
+++ b/get-next-semantic-version/process-latest-prs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FILTERED_PR_DATA="$(echo "$PR_DATA" | jq --arg commit "$LAST_TAG_COMMIT" '.search.edges[] | select(.node.mergeCommit.oid != $commit)')"
+
+echo "$FILTERED_PR_DATA"
+
+version=$(echo "$FILTERED_PR_DATA" | grep -m1 -oi major || echo "$PR_DATA" | grep -m1 -oi minor || echo "$PR_DATA" | grep -m1 -oi patch || echo "")
+version_lower="${version,,}"
+{
+  echo "version=$version_lower"
+  if [ -z "$version" ]; then
+    echo "continue_release=false"
+  else
+    echo "continue_release=true"
+  fi
+} >> "$GITHUB_OUTPUT"
+
+cat "$GITHUB_OUTPUT"


### PR DESCRIPTION
Sometimes the PR merge time and commit time do not match, so PR search can include the PR that we're trying to search *after*.

This adds an additional filter to remove the PR that we're searching from.