### PR TITLE
Bump publish-confluence to latest

### DIFF
--- a/publish-confluence/Dockerfile
+++ b/publish-confluence/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/markdown-confluence/publish:v5.4.0
+FROM ghcr.io/markdown-confluence/publish:v5.5.2
 
 USER root


### PR DESCRIPTION
The issue that caused us to lock to 5.4.0 instead of 5.5.0 is fixed in 5.5.2

upstream only locks to major version so we need to keep this "fork"