### PR TITLE
Revert "Bump publish-confluence to latest"

### DIFF
--- a/publish-confluence/Dockerfile
+++ b/publish-confluence/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/markdown-confluence/publish:v5.5.2
+FROM ghcr.io/markdown-confluence/publish:v5.4.0
 
 USER root


### PR DESCRIPTION
Reverts smartlyio/github-actions#44

new version appears to fail randomly. Maybe old one does too but need to limit unknowns