### PR TITLE
Upgrade setup-node action to version 6

### DIFF
--- a/release-action-node/action.yml
+++ b/release-action-node/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         "$GITHUB_ACTION_PATH/node-version.sh"
     - name: Set Node.js version for the action being released
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ steps.action-node-version.outputs.node-version }}
     - name: Get base branch


### PR DESCRIPTION
Actions which depend on this action receive warning about the Node version 20.x so this should fix it.