### PR TITLE
Bump octokit/graphql-action to v3.x

### DIFF
--- a/create-github-release/action.yml
+++ b/create-github-release/action.yml
@@ -39,7 +39,7 @@ runs:
       run: ${{ github.action_path }}/get-merge-window.sh
       shell: bash
     - name: Get merged PRs
-      uses: octokit/graphql-action@v2.x
+      uses: octokit/graphql-action@v3.x
       id: get-release-prs
       with:
         token: ${{ inputs.token }}


### PR DESCRIPTION
The `octokit/graphql-action` action `v2` uses `node20`, so we need to move to `v3` which uses `node24`.