### PR TITLE
Bump octokit/graphql-action to v3.x

### DIFF
--- a/get-next-semantic-version/action.yml
+++ b/get-next-semantic-version/action.yml
@@ -43,7 +43,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
         cat "$GITHUB_OUTPUT"
     - name: Get PR labels
-      uses: octokit/graphql-action@v2.x
+      uses: octokit/graphql-action@v3.x
       id: get_latest_prs
       with:
         query: |


### PR DESCRIPTION
The `octokit/graphql-action` action `v2` uses `node20`, so we need to move to `v3` which uses `node24`.