### PR TITLE
[VLCN-3624] Bump action-validator to the latest 0.9.0

### DIFF
--- a/action-validator/action.yml
+++ b/action-validator/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: action-validator version to install
     required: false
-    default: 0.6.0
+    default: 0.9.0
 
 runs:
   using: "composite"

--- a/action-validator/action.yml
+++ b/action-validator/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Cache
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: /usr/local/bin/action-validator
         key: action-validator-${{ inputs.version }}


### PR DESCRIPTION
There is an issue in another project [here](https://github.com/smartlyio/github-actions-private/pull/395), where validator cannot recognize the newest version of `using: node24` so we need to bump to the new version.

[Releases](https://github.com/mpalmer/action-validator/releases).