### PR TITLE
[VLCN-3662] Bump action versions to support node 24

### DIFF
--- a/.github/workflows/auto_tagger.yml
+++ b/.github/workflows/auto_tagger.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
       matrix_empty: ${{ steps.get-matrix.outputs.matrix_empty }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: get-matrix
@@ -35,7 +35,7 @@ jobs:
         directory: ${{ fromJson(needs.find_changes.outputs.matrix).directory }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/compare-changes.yml
+++ b/.github/workflows/compare-changes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ubuntu-24.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run tests
         shell: sh

--- a/.github/workflows/find-changes.yml
+++ b/.github/workflows/find-changes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ubuntu-24.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Find changes
         id: changes

--- a/.github/workflows/test_calculate_incremental_tag.yml
+++ b/.github/workflows/test_calculate_incremental_tag.yml
@@ -11,7 +11,7 @@ jobs:
     name: calculate-incremental-tag
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: create_tag
         uses: ./calculate-incremental-tag
       - run: |

--- a/.github/workflows/test_setup_ruby.yml
+++ b/.github/workflows/test_setup_ruby.yml
@@ -17,7 +17,7 @@ jobs:
         version: [ '3.1', '3.2', '3.3' ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: _actions
       - run: |
@@ -38,7 +38,7 @@ jobs:
   #        version: [ '2.7', '3.0', '3.1', '3.2' ]
   #    runs-on: ${{ matrix.os }}
   #    steps:
-  #      - uses: actions/checkout@v4
+  #      - uses: actions/checkout@v6
   #        with:
   #          path: _actions
   #      - run: |

--- a/find-changes/action.yml
+++ b/find-changes/action.yml
@@ -6,13 +6,13 @@ runs:
   steps:
     - if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 2
 
     - if: github.event_name == 'push'
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Find changes
       id: changes

--- a/publish-confluence/README.md
+++ b/publish-confluence/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Publish Markdown to Confluence
         uses: markdown-confluence/publish@v1
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Publish Markdown to Confluence
         uses: markdown-confluence/publish@v1
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Publish Markdown to Confluence
         uses: markdown-confluence/publish@v1

--- a/release/README.md
+++ b/release/README.md
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Create GitHub release
         id: release
         uses: smartlyio/github-actions@release-v1


### PR DESCRIPTION
Existing actions are using node20, so we need to update the actions to the versions which support modern version of node (node24 in this case).