### PR TITLE
Bump remaining action pieces away from node20

### DIFF
--- a/action-validator/action.yml
+++ b/action-validator/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Cache
       id: cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/action-validator
         key: action-validator-${{ inputs.version }}

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Cache
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/actionlint
         key: actionlint-${{ inputs.version }}

--- a/auto-tagger/action.yml
+++ b/auto-tagger/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Push tag
       if: inputs.auto_tag_always == 'true' || (github.event.action == 'closed' && github.event.pull_request.merged)
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v3.x
       with:
         route: POST /repos/:repository/git/refs
         repository: ${{ github.repository }}

--- a/editorconfig-checker/action.yml
+++ b/editorconfig-checker/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Cache Editorconfig-Checker binary
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/editorconfig-checker
         key: EditorConfig-Checker-${{ inputs.version }}

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Prettier
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.npm
         key: prettier-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}

--- a/shellcheck/action.yml
+++ b/shellcheck/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Cache ShellCheck binary
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/shellcheck
         key: shellcheck-${{ inputs.version }}


### PR DESCRIPTION
Accidentally there were a couple of actions left which by default are using Node 20. To avoid any disruptions and future technical debt, let's bump them to the newer versions.