### PR TITLE
Retag actions after Node 24 dependency bumps

### DIFF
--- a/action-validator/action.yml
+++ b/action-validator/action.yml
@@ -1,4 +1,5 @@
 name: action-validator
+# Retag after Node 24 dependency bumps.
 description: Runs action-validator on files tracked by Git.
 inputs:
   version:

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -1,4 +1,5 @@
 name: actionlint
+# Retag after Node 24 dependency bumps.
 description: Runs actionlint with color output
 inputs:
   version:

--- a/auto-tagger/action.yml
+++ b/auto-tagger/action.yml
@@ -1,4 +1,5 @@
 name: Auto tagger
+# Retag after Node 24 dependency bumps.
 description: |
   Creates a new version (tag+branch) for a repository based on the labels "major, minor, patch" associated with the current pull-request.
   

--- a/editorconfig-checker/action.yml
+++ b/editorconfig-checker/action.yml
@@ -1,4 +1,5 @@
 name: Editorconfig-Checker
+# Retag after Node 24 dependency bumps.
 description: Runs Editorconfig-Checker on files tracked by Git.
 inputs:
   version:

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -1,4 +1,5 @@
 name: Prettier
+# Retag after Node 24 dependency bumps.
 description: Run Prettier in check mode.
 inputs:
   patterns:

--- a/shellcheck/action.yml
+++ b/shellcheck/action.yml
@@ -1,4 +1,5 @@
 name: ShellCheck
+# Retag after Node 24 dependency bumps.
 description: Runs ShellCheck with colorful output
 inputs:
   version:


### PR DESCRIPTION
Previous release tagging failed due to missing `GITHUB_TOKEN` write permissions. Touch the affected actions so auto-tagger publishes the pending patch versions.